### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/2024-07/spring-36-37-spring-cloud/elk/docker-compose.yml
+++ b/2024-07/spring-36-37-spring-cloud/elk/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2024-09/spring-34-35-spring-cloud/elk/docker-compose.yml
+++ b/2024-09/spring-34-35-spring-cloud/elk/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2024-11/spring-35-36-spring-cloud/elk/docker-compose.yml
+++ b/2024-11/spring-35-36-spring-cloud/elk/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2025-03/spring-35-36-spring-cloud/elk/docker-compose.yml
+++ b/2025-03/spring-35-36-spring-cloud/elk/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2025-05/spring-35-36-spring-cloud/elk/docker-compose.yml
+++ b/2025-05/spring-35-36-spring-cloud/elk/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2025-07/spring-35-36-spring-cloud/elk/docker-compose.yml
+++ b/2025-07/spring-35-36-spring-cloud/elk/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2025-09/spring-35-36-spring-cloud/elk/docker-compose.yml
+++ b/2025-09/spring-35-36-spring-cloud/elk/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2025-11/spring-35-36-spring-cloud/elk/docker-compose.yml
+++ b/2025-11/spring-35-36-spring-cloud/elk/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:

--- a/2026-01/spring-35-36-spring-cloud/elk/docker-compose.yml
+++ b/2026-01/spring-35-36-spring-cloud/elk/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - "9411"
 
   prometheus:
-    image: bitnami/prometheus:3.0.1
+    image: soldevelo/prometheus:3.0.1
     container_name: prometheus
     network_mode: "host"
     expose:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/prometheus:3.0.1` → [`soldevelo/prometheus:3.0.1`](https://hub.docker.com/r/soldevelo/prometheus)